### PR TITLE
feat: replace regex with dedicated set of chars for different complex…

### DIFF
--- a/src/shh/core.clj
+++ b/src/shh/core.clj
@@ -28,6 +28,7 @@
    2 (map char (concat (range 48 58) (range 65 91) (range 97 123))) ; letters, numbers
    3 (map char (concat (range 65 91) (range 97 123)))})             ; letters
 
+
 (def ^:private messages
   {:name-of-pass       "Shh! What is the name of the password you are looking for?"
    :pass-not-found     "No such password found. Would you like to create one? (yes/no)"


### PR DESCRIPTION
Hello @askonomm
Thanks for merging my previous PR!

Great idea with the password complexity option!
I dived a bit into `generate-password` and found that for medium and easy passwords cases regex logic works almost for no purpose. If I get it right the 1000 characters sequence is processed with regex and only after that we substring first n (length of the password).
My idea is to have a dedicated set of characters for each complexity option.
Also in the same PR I've changed the "copy" message slightly to reflect that the password is copied to the clipboard. 

A couple of things to note:
1) we can randomize the start of substring operation 
2) when we read from the input the values for length complexity there's no `NumberFormatException` handling which parseInt can/will throw. Might be a good idea to add it.

Feel free to merge/decline. Happy to make any amendments if required.
Regards, Eugene