### PR TITLE
Add copy command for windows

### DIFF
--- a/src/shh/core.clj
+++ b/src/shh/core.clj
@@ -88,10 +88,17 @@
           (say! :cannot-copy)
           (say! :password-is password)
           (System/exit 1)))
+
       (= "Mac OS X" os)
       (do
         (sh/sh "pbcopy" "<<<" :in password)
         (say! :copy))
+
+      (string/includes? os "Windows") ; for win 10 and 11 (and even 7)
+      (do
+        (sh/sh "clip" :in password)
+        (say! :copy))
+
       :else
       (println "Password not copied.\nCurrently" os "is not supported"))))
 


### PR DESCRIPTION
This will pretty much add support for windows.

I tried `lein uberjar` and I could use shh as indicated. Creating, changing, and deleting a password work.

The only hitch is you have to run it with.
`java -jar target/shh.jar` 
for some reason the snapshot.jar doesn't work but shh.jar does.

Although I think this hitch can be solved by creating an installer script for windows, what do you think?